### PR TITLE
Added logic for dynamic course initials.

### DIFF
--- a/server/createEnrollmentsFile.js
+++ b/server/createEnrollmentsFile.js
@@ -86,7 +86,7 @@ async function searchGroup (filter, ldapClient) {
  * Fetch the members for the examinator group for this course.
  */
 async function getExaminatorMembers (courseCode, ldapClient) {
-  const courseInitials = courseCode.substring(0, 2)
+  const courseInitials = courseCode.length > 6 ? courseCode.substring(0, 3) : courseCode.substring(0, 2)
   return searchGroup(`(&(objectClass=group)(CN=edu.courses.${courseInitials}.${courseCode}.examiner))`, ldapClient)
 }
 

--- a/server/createEnrollmentsFile.js
+++ b/server/createEnrollmentsFile.js
@@ -90,8 +90,10 @@ async function getExaminatorMembers (courseCode, ldapClient) {
   return searchGroup(`(&(objectClass=group)(CN=edu.courses.${courseInitials}.${courseCode}.examiner))`, ldapClient)
 }
 
-async function writeUsersForCourse ({canvasCourse, ldapClient, fileName}) {
-  const courseInitials = canvasCourse.courseCode.substring(0, 2)
+async function writeUsersForCourse ({canvasCourse, termin, ldapClient, fileName}) {
+  const courseInitials = canvasCourse.courseCode.length > 6 ? canvasCourse.courseCode.substring(0, 3) : canvasCourse.courseCode.substring(0, 2)
+
+
 
   const ugRoleCanvasRole = [
     {type: 'teachers', role: 'teacher'},

--- a/server/createEnrollmentsFile.js
+++ b/server/createEnrollmentsFile.js
@@ -92,8 +92,6 @@ async function getExaminatorMembers (courseCode, ldapClient) {
 
 async function writeUsersForCourse ({canvasCourse, termin, ldapClient, fileName}) {
   const courseInitials = canvasCourse.courseCode.length > 6 ? canvasCourse.courseCode.substring(0, 3) : canvasCourse.courseCode.substring(0, 2)
-
-
 
   const ugRoleCanvasRole = [
     {type: 'teachers', role: 'teacher'},

--- a/server/createEnrollmentsFile.js
+++ b/server/createEnrollmentsFile.js
@@ -90,7 +90,7 @@ async function getExaminatorMembers (courseCode, ldapClient) {
   return searchGroup(`(&(objectClass=group)(CN=edu.courses.${courseInitials}.${courseCode}.examiner))`, ldapClient)
 }
 
-async function writeUsersForCourse ({canvasCourse, termin, ldapClient, fileName}) {
+async function writeUsersForCourse ({canvasCourse, ldapClient, fileName}) {
   const courseInitials = canvasCourse.courseCode.length > 6 ? canvasCourse.courseCode.substring(0, 3) : canvasCourse.courseCode.substring(0, 2)
 
   const ugRoleCanvasRole = [


### PR DESCRIPTION
This is so we can handle the upcoming introduction of research courses. If I recall correctly, the logic introduced in UG was simply based on course code length i.e. if more than 6 characters long, the first 3 instead of 2 will be used to create a subgroup.